### PR TITLE
Fix chunksize not loading for peeler when launched from gui

### DIFF
--- a/tridesclous/catalogueconstructor.py
+++ b/tridesclous/catalogueconstructor.py
@@ -1492,6 +1492,7 @@ class CatalogueConstructor:
         #~ self.catalogue['cluster_colors'].update(self.colors)
         
         #params
+        self.catalogue['chunksize'] = self.info['chunksize']
         self.catalogue['signal_preprocessor_params'] = dict(self.info['signal_preprocessor_params'])
         self.catalogue['peak_detector_params'] = dict(self.info['peak_detector_params'])
         self.catalogue['clean_waveforms_params'] = dict(self.info['clean_waveforms_params'])

--- a/tridesclous/gui/mainwindow.py
+++ b/tridesclous/gui/mainwindow.py
@@ -412,7 +412,7 @@ class MainWindow(QT.QMainWindow):
             #~ if True:
                 initial_catalogue = self.dataio.load_catalogue(chan_grp=chan_grp)
                 if initial_catalogue is None:
-                    txt =  """chran_grp{}
+                    txt =  """chan_grp{}
 Catalogue do not exists, please do:
     1. Initialize Catalogue (if not done)
     2. Open CatalogueWindow
@@ -420,6 +420,10 @@ Catalogue do not exists, please do:
                     """.format(chan_grp)
                     errors.append(txt)
                     continue
+                try:
+                    d['chunksize'] = initial_catalogue['chunksize']
+                except KeyError as e:
+                    print('chunksize was not saved with catalogue, peeler will use default chunksize')
                 
                 peeler = Peeler(self.dataio)
                 peeler.change_params(catalogue=initial_catalogue, **d)
@@ -431,7 +435,7 @@ Catalogue do not exists, please do:
                 
             except Exception as e:
                 print(e)
-                error = """chran_grp{}\n{}""".format(chan_grp, e)
+                error = """chan_grp{}\n{}""".format(chan_grp, e)
                 errors.append(error)
         
         for error in errors:

--- a/tridesclous/peeler.py
+++ b/tridesclous/peeler.py
@@ -345,7 +345,7 @@ class Peeler:
         p['signals_mads'] = self.catalogue['signals_mads']
         self.signalpreprocessor.change_params(**p)
         
-        assert self.chunksize>self.signalpreprocessor.lostfront_chunksize
+        assert self.chunksize>self.signalpreprocessor.lostfront_chunksize, 'lostfront_chunksize ({}) is greater than chunksize ({})!'.format(self.signalpreprocessor.lostfront_chunksize, self.chunksize)
         
         self.internal_dtype = self.signalpreprocessor.output_dtype
 


### PR DESCRIPTION
In `MainWindow.run_peeler`, `peeler.change_params` is called without passing in the `chunksize`. This sets the Peeler's `chunksize` to the default value of 1024.

To pass the correct `chunksize` to `peeler.change_params`, the `chunksize` must be retrieved. If the `chunksize` was set in `dialog_fullchain_params` this session, it would be possible to retrieve it from there. However, if a data set was loaded with a previously initialized catalogue, the default value found in `dialog_fullchain_params` will be incorrect.

So, to solve this problem, this commit first adds `chunksize` to `CatalogueConstructor.make_catalogue` so that it can be saved by `CatalogueConstructor.make_catalogue_for_peeler` and `DataIO.save_catalogue`. Second, the commit extracts the `chunksize` from `initial_catalogue` after it has been loaded by `DataIO.load_catalogue` inside `MainWindow.run_peeler` and passes it with the other parameters to `peeler.change_params`.

Extraction of the new `chunksize` parameter from `initial_catalogue` is wrapped in a `try` statement for backwards compatibility with old catalogues created before this fix.