### PR TITLE
Bug fix: Load default for lostfront_chunksize in set_preprocessor_params

### DIFF
--- a/tridesclous/catalogueconstructor.py
+++ b/tridesclous/catalogueconstructor.py
@@ -364,6 +364,11 @@ class CatalogueConstructor:
         self.chunksize = chunksize
         self.memory_mode = memory_mode
         
+        # set default lostfront_chunksize if none is provided
+        if lostfront_chunksize is None or lostfront_chunksize==0:
+            assert highpass_freq is not None, 'lostfront_chunksize=None needs a highpass_freq'
+            lostfront_chunksize = int(self.dataio.sample_rate/highpass_freq*3)
+        
         #~ self.arrays.initialize_array('all_peaks', self.memory_mode,  _dtype_peak, (-1, ))
         
         self.signal_preprocessor_params = dict(highpass_freq=highpass_freq, lowpass_freq=lowpass_freq, 

--- a/tridesclous/signalpreprocessor.py
+++ b/tridesclous/signalpreprocessor.py
@@ -77,7 +77,7 @@ class SignalPreprocessor_base:
                                             normalize=True,
                                             lostfront_chunksize = None,
                                             signals_medians=None, signals_mads=None):
-        
+                
         self.signals_medians = signals_medians
         self.signals_mads = signals_mads
         
@@ -89,8 +89,9 @@ class SignalPreprocessor_base:
         self.normalize = normalize
         self.lostfront_chunksize = lostfront_chunksize
         
+        # set default lostfront_chunksize if none is provided
         if self.lostfront_chunksize is None or self.lostfront_chunksize==0:
-            assert self.highpass_freq is not None, 'lostfront_chunksize=None need a highpass_freq'
+            assert self.highpass_freq is not None, 'lostfront_chunksize=None needs a highpass_freq'
             self.lostfront_chunksize = int(self.sample_rate/self.highpass_freq*3)
             #~ print('self.lostfront_chunksize', self.lostfront_chunksize)
         


### PR DESCRIPTION
The docstring for `CatalogueConstructor.set_preprocessor_params` claims that a reasonable value for `lostfront_chunksize` is set by default if `None` is provided. However, the code that sets this value is located in `SignalPreprocessor_base.change_params` and may not be executed before it's needed.

For example, if `estimate_signals_noise` is run immediately after `set_preprocessor_params(lostfront_chunksize = None, ...)` (as is the case with `apply_all_catalogue_steps`), a `TypeError` occurs because `lostfront_chunksize` is still `None`.

This commit duplicates the code for setting the default value into `set_preprocessor_params` to avoid this bug.