### PR TITLE
support TDC_IN_CONTAINER env variable

### DIFF
--- a/tridesclous/__init__.py
+++ b/tridesclous/__init__.py
@@ -12,7 +12,12 @@
 """
 from .version import version as __version__
 
-import PyQt5 # this force pyqtgraph to deal with Qt5
+import os
+if os.getenv('TDC_IN_CONTAINER', None) == '1':
+    import matplotlib
+    matplotlib.use('agg')
+
+# import PyQt5 # this force pyqtgraph to deal with Qt5
 
 # For matplotlib to Qt5 : 
 #   * this avoid tinker problem when not installed

--- a/tridesclous/catalogueconstructor.py
+++ b/tridesclous/catalogueconstructor.py
@@ -6,6 +6,10 @@
 
 """
 
+import os
+if os.getenv('TDC_IN_CONTAINER', None) == '1':
+    import matplotlib
+    matplotlib.use('agg')
 
 import os
 import json


### PR DESCRIPTION
Hey @samuelgarcia, This is what I needed to do in order to get tdc to run without complaint inside a docker container. I tried a number of other workarounds, but this was the only one that did the trick for me. It was complaining about the Qt5Agg backend for matplotlib. Even if I set `matplotlib.use('agg')` in my source code, it would still struggle at various points in the process.

For reference here is my Dockerfile (note that it sets the TDC_IN_CONTAINER=1) env variable:
https://github.com/flatironinstitute/spikeforest/blob/sorting/spikeforest/sorters/tridesclous/docker/Dockerfile

Also for reference, here's the python wrapper:
https://github.com/flatironinstitute/spikeforest/blob/sorting/spikeforest/sorters/tridesclous/tridesclous_wrapper1.py