### PR TITLE
Eliminate deprecated use of np.float

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.22
+numpy
 scipy
 pandas
 openpyxl

--- a/tridesclous/dip.py
+++ b/tridesclous/dip.py
@@ -58,7 +58,7 @@ def diptest(dat, is_hist=False, numt=1000):
     # count dips greater or equal to d, add 1/1 to prevent a pvalue of 0
     pval = None \
       if unif_dips.sum() == 0 else \
-        (np.less(d, unif_dips).sum() + 1) / (np.float(numt) + 1)
+        (np.less(d, unif_dips).sum() + 1) / (float(numt) + 1)
     
     return pval
     #~ return (d, pval, # dip, pvalue


### PR DESCRIPTION
Related to this:
https://github.com/SpikeInterface/spikeinterface/pull/1852

np.float is deprecated:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations