### PR TITLE
Switch NumPy deprecation np.in1d -> np.isin

### DIFF
--- a/tridesclous/catalogueconstructor.py
+++ b/tridesclous/catalogueconstructor.py
@@ -1658,7 +1658,7 @@ class CatalogueConstructor:
         This is a manual action.
         
         """
-        inds, = np.nonzero(np.in1d(self.clusters['cluster_label'], labels_to_group))
+        inds, = np.nonzero(np.isin(self.clusters['cluster_label'], labels_to_group))
         self.clusters['cell_label'][inds] = min(labels_to_group)
     
 

--- a/tridesclous/decomposition.py
+++ b/tridesclous/decomposition.py
@@ -225,7 +225,7 @@ class PcaByChannel:
                 #~ print('dense', wf_chan.shape)
                 features[:, chan*n:(chan+1)*n] = pca.transform(wf_chan)
             elif cc.mode == 'sparse':
-                sel = np.in1d(some_peaks['channel'], channel_adjacency[chan])
+                sel = np.isin(some_peaks['channel'], channel_adjacency[chan])
                 #~ print(chan, np.sum(sel))
                 wf_chan = cc.get_some_waveforms(peaks_index=cc.some_peaks_index[sel], channel_indexes=[chan])
                 wf_chan = wf_chan[:, :, 0]

--- a/tridesclous/gui/cataloguecontroller.py
+++ b/tridesclous/gui/cataloguecontroller.py
@@ -332,7 +332,7 @@ class CatalogueController(ControllerBase):
     
     def update_visible_spikes(self):
         visibles = np.array([k for k, v in self.cluster_visible.items() if v ])
-        self.spike_visible[:] = np.in1d(self.spike_label, visibles)
+        self.spike_visible[:] = np.isin(self.spike_label, visibles)
 
     def on_cluster_visibility_changed(self):
         self.update_visible_spikes()

--- a/tridesclous/gui/peelercontroller.py
+++ b/tridesclous/gui/peelercontroller.py
@@ -227,7 +227,7 @@ class PeelerController(ControllerBase):
         #~ ['selected', 'all',  'collision']
         if self.spike_visible_mode=='selected':
             visibles = np.array([k for k, v in self.cluster_visible.items() if v ])
-            self.spikes['visible'][:] = np.in1d(self.spikes['cluster_label'], visibles)
+            self.spikes['visible'][:] = np.isin(self.spikes['cluster_label'], visibles)
         elif self.spike_visible_mode=='all':
             self.spikes['visible'][:] = True
         elif self.spike_visible_mode=='collision':

--- a/tridesclous/gui/similarity.py
+++ b/tridesclous/gui/similarity.py
@@ -117,7 +117,7 @@ class SpikeSimilarityView(BaseSimilarityView):
         visibles = [c for c, v in self.controller.cluster_visible.items() if v and c>=0]
         
         labels = self.controller.spike_label[self.controller.some_peaks_index]
-        keep_ind,  = np.nonzero(np.in1d(labels, visibles))
+        keep_ind,  = np.nonzero(np.isin(labels, visibles))
         keep_label = labels[keep_ind]
         order = np.argsort(keep_label)
         keep_ind = keep_ind[order]

--- a/tridesclous/gui/waveformhistviewer.py
+++ b/tridesclous/gui/waveformhistviewer.py
@@ -295,7 +295,7 @@ class WaveformHistViewer(WidgetBase):
                 return
 
             labels = self.controller.spike_label[self.controller.some_peaks_index]
-            keep = np.in1d(labels, visibles)
+            keep = np.isin(labels, visibles)
             ind_keep,  = np.nonzero(keep)
             
             nb_feature_by_channel = data.shape[1] // self.controller.nb_channel

--- a/tridesclous/pruningshears.py
+++ b/tridesclous/pruningshears.py
@@ -187,7 +187,7 @@ class PruningShears:
         order_visit = np.argsort(percentiles)[::-1]
         percentiles = percentiles[order_visit]
         
-        mask = (percentiles > 0) & ~np.in1d(order_visit, chan_visited)
+        mask = (percentiles > 0) & ~np.isin(order_visit, chan_visited)
         
         order_visit = order_visit[mask]
         percentiles = percentiles[mask]

--- a/tridesclous/sawchaincut.py
+++ b/tridesclous/sawchaincut.py
@@ -248,7 +248,7 @@ class SawChainCut:
             #~ self.log(percentiles[order_visit])
             
             
-            order_visit = order_visit[~np.in1d(order_visit, chan_visited)]
+            order_visit = order_visit[~np.isin(order_visit, chan_visited)]
             
             if len(order_visit)==0:
                 self.log('len(order_visit)==0')

--- a/tridesclous/tests/test_catalogueconstructor.py
+++ b/tridesclous/tests/test_catalogueconstructor.py
@@ -331,7 +331,7 @@ def test_feature_with_lda_selection():
     cc = CatalogueConstructor(dataio=dataio)
     print(cc)
     
-    selection = np.in1d(cc.all_peaks['cluster_label'], [1, 2, 3, 4])
+    selection = np.isin(cc.all_peaks['cluster_label'], [1, 2, 3, 4])
     print(np.sum(selection), '/', cc.all_peaks.size)
     
     cc.extract_some_features(method='global_lda',  selection=selection)

--- a/tridesclous/tools.py
+++ b/tridesclous/tools.py
@@ -271,7 +271,7 @@ def compute_cross_correlograms(spike_indexes, spike_labels,
         shift = 1
 
         
-        keep = (spike_segments==seg_num) & np.in1d(spike_labels, cluster_labels)
+        keep = (spike_segments==seg_num) & np.isin(spike_labels, cluster_labels)
         sp_indexes = spike_indexes[keep]
         sp_labels = spike_labels[keep]
         sp_segments = spike_segments[keep]


### PR DESCRIPTION
@samuelgarcia,

Just wanted this to serve as note to remember to update tridesclous for future numpy releases if things check install for spikeinterface will use tridesclous rather than tridesclous2.