### PR TITLE
Replace deprecated `np.in1d` with `np.isin` for label filtering

### DIFF
--- a/tridesclous/pruningshears.py
+++ b/tridesclous/pruningshears.py
@@ -476,7 +476,7 @@ class PruningShears:
             else:
                 #~ peak_max = self.all_peak_max[mask_loop, :]
                 #~ mask_thresh[mask_loop] = peak_max[:, actual_chan] > self.threshold
-                mask_thresh[mask_loop] = np.in1d(self.peaks['channel'][mask_loop], high_adjacency)
+                mask_thresh[mask_loop] = np.isin(self.peaks['channel'][mask_loop], high_adjacency)
                 
             self.log('mask_loop.size', mask_loop.size, 'mask_loop.sum', mask_loop.sum(), 'mask_thresh.sum', mask_thresh.sum())
             

--- a/tridesclous/pruningshears.py
+++ b/tridesclous/pruningshears.py
@@ -694,7 +694,7 @@ class PruningShears:
                 #~ bad_labels = possible_labels_l0[~peak_is_aligned & peak_is_on_chan]
                 # put aligned False
                 bad_labels = possible_labels_l0[~peak_is_aligned]
-                ind_trash_label = ind_l0[np.in1d(labels_l0, bad_labels)]
+                ind_trash_label = ind_l0[np.isin(labels_l0, bad_labels)]
                 self.log('trash bad_labels for trash', bad_labels, 'n=', ind_trash_label.size)
                 cluster_labels[ind_trash_label] = -1
                 


### PR DESCRIPTION
This deprecated function is removed in `numpy=2.4`, so can cause error. Simply replace it with `np.isin`.

The example traceback is:

```python
E           Traceback (most recent call last):
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/spikeinterface/sorters/basesorter.py", line 266, in run_from_folder
E               SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
E               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/spikeinterface/sorters/external/tridesclous.py", line 138, in _run_from_folder
E               tdc.apply_all_catalogue_steps(cc, catalogue_nested_params, verbose=verbose)
E               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/tridesclous/cataloguetools.py", line 119, in apply_all_catalogue_steps
E               cc.find_clusters(method=params['cluster_method'], recompute_centroid=False, order=False, **params['cluster_kargs'])
E               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/tridesclous/catalogueconstructor.py", line 1173, in find_clusters
E               labels = cluster.find_clusters(self, method=method, selection=selection, **kargs)
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/tridesclous/cluster.py", line 164, in find_clusters
E               labels = pruningshears.do_the_job()
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/tridesclous/pruningshears.py", line 135, in do_the_job
E               cluster_labels = self.explore_split_loop()
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/tridesclous/pruningshears.py", line 697, in explore_split_loop
E               ind_trash_label = ind_l0[np.in1d(labels_l0, bad_labels)]
E                                        ^^^^^^^
E             File "/home/zhangyiqin/miniforge3/envs/dbci/lib/python3.13/site-packages/numpy/__init__.py", line 792, in __getattr__
E               raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
E           AttributeError: module 'numpy' has no attribute 'in1d'. Did you mean: 'int16'?
E           
E           Spike sorting failed. You can inspect the runtime trace in /tmp/tmpsxmgx7z9/work/Sorter/spikeinterface_log.json.

../../../miniforge3/envs/dbci/lib/python3.13/site-packages/spikeinterface/sorters/basesorter.py:306: SpikeSortingError
```